### PR TITLE
Allow } else { and trailing comma

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -17,7 +17,7 @@
   ],
   "disallowMixedSpacesAndTabs": true,
   "disallowTrailingWhitespace": true,
-  "disallowTrailingComma": true,
+  "disallowTrailingComma": false,
   "disallowYodaConditions": true,
   "disallowKeywords": ["with"],
   "disallowMultipleLineBreaks": true,
@@ -35,7 +35,6 @@
   "requireDotNotation": true,
   "requireSpacesInForStatement": true,
   "requireSpaceBetweenArguments": true,
-  "requireKeywordsOnNewLine": ["else"],
   "requireCurlyBraces": [ "do" ],
   "requireSpaceBeforeKeywords": ["if"],
   "requireSpaceAfterKeywords": [


### PR DESCRIPTION
this is very low-PRI

I like

```
if (expr) {
  statements
} else {
  statements
}
```

over

```
if (expr) {
  statements
}
else
{
  statements
}
```

and I like trailing commas because in diffs adding a new item to a newline separated list causes 1 line of change, not 2, and updating those lists is easier.
